### PR TITLE
Got rid of the redundant getter methods in GraphNode to populate the UI table

### DIFF
--- a/src/main/java/graph/GraphNode.java
+++ b/src/main/java/graph/GraphNode.java
@@ -70,6 +70,10 @@ public class GraphNode {
         return _startTime;
     }
 
+    public int getEndTime() {
+        return _endTime;
+    }
+
     public void setStartTime(int startTime) {
         _startTime = startTime;
     }
@@ -96,24 +100,5 @@ public class GraphNode {
         this._computationalBottomLevel = computationalBottomLevel;
     }
 
-    //Framework Specific Auto Generated Getters for the Table Population
-    public String get_id() {
-        return _id;
-    }
 
-    public int get_weight() {
-        return _weight;
-    }
-
-    public int get_processor() {
-        return _processor;
-    }
-
-    public int get_startTime() {
-        return _startTime;
-    }
-
-    public int get_endTime() {
-        return _endTime;
-    }
 }

--- a/src/main/java/visualisation/controller/MainController.java
+++ b/src/main/java/visualisation/controller/MainController.java
@@ -214,10 +214,10 @@ public class MainController implements IObserver, ITimerObserver, Initializable 
     }
 
     private void initializeTable() {
-        taskIDColumn.setCellValueFactory(new PropertyValueFactory<>("_id"));
-        startTimeColumn.setCellValueFactory(new PropertyValueFactory<>("_startTime"));
-        endTimeColumn.setCellValueFactory(new PropertyValueFactory<>("_endTime"));
-        assignedProcessorColumn.setCellValueFactory((new PropertyValueFactory<>("_processor")));
+        taskIDColumn.setCellValueFactory(new PropertyValueFactory<>("id"));
+        startTimeColumn.setCellValueFactory(new PropertyValueFactory<>("startTime"));
+        endTimeColumn.setCellValueFactory(new PropertyValueFactory<>("endTime"));
+        assignedProcessorColumn.setCellValueFactory((new PropertyValueFactory<>("processor")));
         scheduleResultsTable.setItems(_tablePopulationList);
     }
 


### PR DESCRIPTION
Quick fix to remove the redundant getters from the GraphNode class. Please note even though the IDE says that getEndTime() is not being used, it is being used by the JavaFX framework, just not explicitly by our code. 